### PR TITLE
Added link to The R Blog post regarding support for Apple Silicon

### DIFF
--- a/index.in.html
+++ b/index.in.html
@@ -44,6 +44,7 @@ Starting with R 4.0.0 alpha we are building R using standard Apple tools (Xcode 
 <!-- <li><a href=/exp/>Experimental 64-bit build of R</a></li> -->
 <li><a href=#old>Legacy OS X support</a></li>
 <li><a href=#other>Other binaries and tools (e.g. RSwitch, Graphviz, GTK+, ..)</a></li>
+<li><a href="https://developer.r-project.org/Blog/public/2020/11/02/will-r-work-on-apple-silicon/index.html" rel="nofollow">Will R Work on Apple Silicon?</a> <i>(Information on the status of the port to Apple's new M1 architecture.)</i>
 </ul>
 
 <a name=nightly></a>


### PR DESCRIPTION
I've seen a couple questions floating around Reddit and other boards and figured having the link to the 👍🏽 blog post wouldn't hurt in the event folks hit this website regularly.