### PR TITLE
Clarifying flag sets in bash and fix spacing

### DIFF
--- a/openmp/index.html
+++ b/openmp/index.html
@@ -107,9 +107,13 @@
 	  add <tt>-lomp</tt> to <tt>LIBS</tt></li>
     </ul>
     How you do the latter depends on the package, but if the package does
-    not set these environment variables itself, you can try
+    not set these environment variables itself, you can try setting the 
+    following environment variables in bash before installing the package:
     <pre>
-    PKG_CPPFLAGS='-Xclang -fopenmp' PKG_LIBS=-lomp R CMD INSTALL myPackage</pre>
+    PKG_CPPFLAGS='-Xclang -fopenmp'
+    PKG_LIBS=-lomp 
+    
+    R CMD INSTALL myPackage</pre>
 
     If that doesn't work, please consult the package's documentation, and
     liaise with its maintainer.


### PR DESCRIPTION
Fixes spacing on flag set commands and emphasizes the flags should be set in BASH prior to calling `R CMD install ...`

<img width="876" alt="fix-macos-flags" src="https://user-images.githubusercontent.com/833642/112026987-c2d80880-8b04-11eb-95d9-49f417b5c567.png">
